### PR TITLE
bugfix: correct checkbox margins and gap based on design

### DIFF
--- a/src/ui/forms/checkboxes/checkbox/checkbox.jsx
+++ b/src/ui/forms/checkboxes/checkbox/checkbox.jsx
@@ -37,7 +37,7 @@ Checkbox.defaultProps = {
   label: '',
   htmlType: 'checkbox',
   reverse: false,
-  gap: '12px',
+  gap: '8px',
   width: '',
 };
 

--- a/src/ui/forms/checkboxes/checkbox/checkbox.module.scss
+++ b/src/ui/forms/checkboxes/checkbox/checkbox.module.scss
@@ -42,6 +42,7 @@
 .checkbox {
   width: 16px;
   height: 16px;
+  margin: 4px;
   border-radius: 1.25px;
   border: 1.5px solid var(--primary-purple-color);
   display: inline-block;


### PR DESCRIPTION
Добавлены внешние отступы чекбокса и исправлен промежуток.

![image](https://github.com/veterinary-salons/frontend/assets/113764110/5b5de408-8e2b-421a-a64b-d82dc20fe53c)
